### PR TITLE
Disallow using discord cdn links because they expire

### DIFF
--- a/src/main/java/de/slimecloud/slimeball/config/engine/ConfigFieldType.java
+++ b/src/main/java/de/slimecloud/slimeball/config/engine/ConfigFieldType.java
@@ -311,6 +311,12 @@ public enum ConfigFieldType {
 		public Object parse(@NotNull Class<?> type, @NotNull String value) {
 			return value;
 		}
+
+		@NotNull
+		@Override
+		public String toString(@NotNull Object value) {
+			return value == null ? "" : value.toString();
+		}
 	},
 
 

--- a/src/main/java/de/slimecloud/slimeball/features/level/card/CardCommand.java
+++ b/src/main/java/de/slimecloud/slimeball/features/level/card/CardCommand.java
@@ -116,7 +116,16 @@ public class CardCommand {
 					),
 					(state, response) -> {
 						try {
-							bot.getCardProfiles().getProfile(state.getEvent().getMember()).getData().set(state.getState("field", String.class), response.getString("value")).upsert();
+							String name = state.getState("field", String.class);
+							String value = response.getString("value");
+
+							if (name.equals("backgroundImageURL") && value.contains("cdn.discordapp.com")) {
+								manager.getMenu("card.edit").display(state.getEvent());
+								state.getEvent().getHook().sendMessage(":x: Ungültige Eingabe! Aus technischen Gründen können Discord-Links nicht verwendet werden. Bei Fragen melde dich gerne bei den Netrunnern :)").setEphemeral(true).queue();
+								return;
+							}
+
+							bot.getCardProfiles().getProfile(state.getEvent().getMember()).getData().set(name, value).upsert();
 							manager.getMenu("card.edit").display(state.getEvent());
 						} catch (ValidationException e) {
 							manager.getMenu("card.edit").display(state.getEvent());
@@ -148,9 +157,9 @@ public class CardCommand {
 				if (field.getType().isAssignableFrom(Style.class)) temp.add(new StyleComponent(field));
 				else if (field.getType().isAssignableFrom(RankColor.class)) temp.add(new RankStyleComponent(field));
 				else temp.add(0, new ButtonComponent(field.getName(), name.length > 1 ? ButtonColor.GRAY : ButtonColor.BLUE, StringUtil.prettifyCamelCase(field.getName())).appendHandler(s -> input.createState()
-							.setState("field", field.getName())
-							.display((IModalCallback) s.getEvent())
-					));
+						.setState("field", field.getName())
+						.display((IModalCallback) s.getEvent())
+				));
 			}
 
 			if (!temp.isEmpty()) components.add(ComponentRow.of(temp));

--- a/src/main/java/de/slimecloud/slimeball/features/level/card/GuildCardProfile.java
+++ b/src/main/java/de/slimecloud/slimeball/features/level/card/GuildCardProfile.java
@@ -56,6 +56,6 @@ public class GuildCardProfile implements DataClass<GuildCardProfile> {
 
 	@NotNull
 	public CardProfileData getData() {
-		return bot.getProfileData().getData(id, user).orElseThrow();
+		return bot.getProfileData().getData(id, user).orElseGet(() -> new CardProfileData(bot));
 	}
 }


### PR DESCRIPTION
## Checklist

 - [x] Read [Contribution Guidelines](https://github.com/SlimeCloud/java-SlimeBot#-contributing) and [Style Guides](https://github.com/SlimeCloud/java-SlimeBot#-style-guide)
 - [x] Test the Code
 - [x] This PR is ready to review and merge

## Description
This disallows using discord cdn links as background url for rank cards because they will no longer works after 2 weeks because of expiry

## Other Information
See https://discord.com/channels/1077255218728796192/1077261949357797386/1276236467588563106